### PR TITLE
Add module-level consent popup with opt-in & opt-out

### DIFF
--- a/src/components/ContentBlock.tsx
+++ b/src/components/ContentBlock.tsx
@@ -26,7 +26,7 @@ import * as RechartsPrimitive from 'recharts';
 
 
 function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { type: 'poll' }>; moduleId: number }) {
-  const { sessionId } = useSession();
+  const { sessionId, studyConsent } = useSession();
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [otherText, setOtherText] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -98,6 +98,16 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    if (studyConsent !== 'in') {
+      if (studyConsent === null) {
+        window.dispatchEvent(new Event('study_consent_request'));
+      }
+      setSubmitError(studyConsent === 'out'
+        ? 'You opted out of the study; your responses will not be submitted.'
+        : 'Please choose whether to participate in the study before submitting.'
+      );
+      return;
+    }
     const responseDisplay = (() => {
       const parts = selectedOptions.filter(o => o !== 'Other');
       if (selectedOptions.includes('Other') && otherText.trim() !== '') {
@@ -255,7 +265,7 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
 }
 
 function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockType, { type: 'module-feedback' }>; moduleId: number }) {
-  const { sessionId } = useSession();
+  const { sessionId, studyConsent } = useSession();
   const [rating, setRating] = useState(0);
   const [hoverRating, setHoverRating] = useState(0);
   const [feedback, setFeedback] = useState('');
@@ -267,6 +277,16 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    if (studyConsent !== 'in') {
+      if (studyConsent === null) {
+        window.dispatchEvent(new Event('study_consent_request'));
+      }
+      setSubmitError(studyConsent === 'out'
+        ? 'You opted out of the study; your responses will not be submitted.'
+        : 'Please choose whether to participate in the study before submitting.'
+      );
+      return;
+    }
     const input = JSON.stringify({
       type: block.type,
       title: block.title,
@@ -299,6 +319,16 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
 
   const handleExport = async () => {
     if (isExporting) return;
+    if (studyConsent !== 'in') {
+      if (studyConsent === null) {
+        window.dispatchEvent(new Event('study_consent_request'));
+      }
+      setExportError(studyConsent === 'out'
+        ? 'You opted out of the study; there are no stored responses to export.'
+        : 'Please choose whether to participate in the study before exporting.'
+      );
+      return;
+    }
     trackEvent('download_pdf', { module_id: moduleId });
     setIsExporting(true);
     setExportError(null);
@@ -403,7 +433,7 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
 }
 
 function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType, { type: 'reflection' }>; moduleId: number }) {
-  const { sessionId } = useSession();
+  const { sessionId, studyConsent } = useSession();
   const { t } = useLanguage();
   const [reflectionText, setReflectionText] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -427,6 +457,16 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    if (studyConsent !== 'in') {
+      if (studyConsent === null) {
+        window.dispatchEvent(new Event('study_consent_request'));
+      }
+      setSubmitError(studyConsent === 'out'
+        ? 'You opted out of the study; your responses will not be submitted.'
+        : 'Please choose whether to participate in the study before submitting.'
+      );
+      return;
+    }
     const submittedText = reflectionText.trim();
     const input = JSON.stringify({
       type: block.type,
@@ -512,7 +552,7 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
 }
 
 function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlockType, { type: 'numeric-prediction' }>; moduleId: number }) {
-  const { sessionId } = useSession();
+  const { sessionId, studyConsent } = useSession();
   const [valueText, setValueText] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -535,6 +575,16 @@ function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlo
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    if (studyConsent !== 'in') {
+      if (studyConsent === null) {
+        window.dispatchEvent(new Event('study_consent_request'));
+      }
+      setSubmitError(studyConsent === 'out'
+        ? 'You opted out of the study; your responses will not be submitted.'
+        : 'Please choose whether to participate in the study before submitting.'
+      );
+      return;
+    }
     const valueNumber = valueText.trim() === '' ? null : Number(valueText);
     const submittedValue = valueText.trim() === '' ? '' : `${valueText.trim()}${block.unit ? ` ${block.unit}` : ''}`;
 

--- a/src/components/FlexibleModulePage.tsx
+++ b/src/components/FlexibleModulePage.tsx
@@ -7,6 +7,17 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { GlossaryHighlightProvider } from '../contexts/GlossaryHighlightContext';
 import { Button } from './ui/button';
 import { trackEvent } from '../utils/analytics';
+import { useSession } from '../contexts/SessionContext';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
 
 const MODULE_QUOTES: Record<number, { text: string; author: string }> = {
   1: {
@@ -44,8 +55,11 @@ export function FlexibleModulePage({
   const navigate = useNavigate();
   const { search } = useLocation();
   const [currentBlock, setCurrentBlock] = useState(1);
+  const [isConsentDialogOpen, setIsConsentDialogOpen] = useState(false);
+  const { studyConsent, setStudyConsent, clearModuleStoredData } = useSession();
   const totalModules = moduleStructures.length;
   const isLastModule = moduleId >= totalModules;
+  const consentOpenTimeoutRef = useRef<number | null>(null);
 
   // Build per-block navigation groups.
   // For Module 1 we use the existing hand-crafted grouping.
@@ -132,6 +146,38 @@ export function FlexibleModulePage({
       }
     };
   }, [moduleId, module.title]);
+
+  useEffect(() => {
+    if (consentOpenTimeoutRef.current !== null) {
+      window.clearTimeout(consentOpenTimeoutRef.current);
+      consentOpenTimeoutRef.current = null;
+    }
+    setIsConsentDialogOpen(false);
+
+    if (studyConsent !== null) return;
+    consentOpenTimeoutRef.current = window.setTimeout(() => {
+      setIsConsentDialogOpen(true);
+    }, 10000);
+
+    return () => {
+      if (consentOpenTimeoutRef.current !== null) {
+        window.clearTimeout(consentOpenTimeoutRef.current);
+        consentOpenTimeoutRef.current = null;
+      }
+    };
+  }, [moduleId, studyConsent]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (studyConsent !== null) return;
+      setIsConsentDialogOpen(true);
+    };
+
+    window.addEventListener('study_consent_request', handler);
+    return () => {
+      window.removeEventListener('study_consent_request', handler);
+    };
+  }, [studyConsent]);
 
   useEffect(() => {
     trackEvent('module_step_view', {
@@ -270,6 +316,36 @@ export function FlexibleModulePage({
 
   return (
     <div className="min-h-screen py-8 px-4 sm:px-6 lg:px-8 font-sora">
+      <AlertDialog open={isConsentDialogOpen} onOpenChange={setIsConsentDialogOpen}>
+        <AlertDialogContent className="font-sora">
+          <AlertDialogHeader>
+            <AlertDialogTitle>MIT Research Study</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your responses will contribute to a MIT research study on how learners feel about climate change. All data is collected anonymously (you can choose to opt out of the study and your data will be deleted after your session). At the end of each module, you can download your responses for your own use.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="justify-center sm:justify-center">
+            <AlertDialogCancel
+              onClick={() => {
+                setStudyConsent('out');
+                clearModuleStoredData();
+                setIsConsentDialogOpen(false);
+                navigate('/');
+              }}
+            >
+              Opt out
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setStudyConsent('in');
+                setIsConsentDialogOpen(false);
+              }}
+            >
+              Count me in!
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-gray-800 rounded-2xl sm:rounded-3xl shadow-2xl overflow-hidden">
           {/* Header */}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -28,40 +28,49 @@ function AlertDialogPortal({
   );
 }
 
-function AlertDialogOverlay({
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ 
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+}, ref) => {
   return (
     <AlertDialogPrimitive.Overlay
+      ref={ref}
       data-slot="alert-dialog-overlay"
+      style={{ position: "fixed", top: 0, right: 0, bottom: 0, left: 0 }}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
         className,
       )}
       {...props}
     />
   );
-}
+});
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
-function AlertDialogContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
+        ref={ref}
         data-slot="alert-dialog-content"
+        style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)" }}
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-[min(92vw,44rem)] gap-4 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 shadow-2xl",
           className,
         )}
         {...props}
       />
     </AlertDialogPortal>
   );
-}
+});
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 function AlertDialogHeader({
   className,
@@ -99,7 +108,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold", className)}
+      className={cn("text-gray-900 dark:text-gray-100 text-lg font-semibold", className)}
       {...props}
     />
   );
@@ -112,7 +121,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-gray-700 dark:text-gray-300 text-sm", className)}
       {...props}
     />
   );

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -9,9 +9,14 @@ function generateSessionId(): string {
     });
 }
 
+export type StudyConsent = 'in' | 'out' | null;
+
 interface SessionContextType {
     sessionId: string;
     startNewSession: () => void;
+    studyConsent: StudyConsent;
+    setStudyConsent: (consent: Exclude<StudyConsent, null>) => void;
+    clearModuleStoredData: () => void;
 }
 
 const SessionContext = createContext<SessionContextType | undefined>(undefined);
@@ -42,6 +47,12 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
         return newId;
     });
 
+    const [studyConsent, setStudyConsentState] = useState<StudyConsent>(() => {
+        const storageKey = `module_${moduleId}_study_consent`;
+        const stored = localStorage.getItem(storageKey);
+        return stored === 'in' || stored === 'out' ? stored : null;
+    });
+
     // Update session ID when module changes
     useEffect(() => {
         const storageKey = `module_${moduleId}_session`;
@@ -61,6 +72,12 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
         }
     }, [moduleId]);
 
+    useEffect(() => {
+        const storageKey = `module_${moduleId}_study_consent`;
+        const stored = localStorage.getItem(storageKey);
+        setStudyConsentState(stored === 'in' || stored === 'out' ? stored : null);
+    }, [moduleId]);
+
     const startNewSession = () => {
         const storageKey = `module_${moduleId}_session`;
         const newId = generateSessionId();
@@ -68,8 +85,34 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
         setSessionId(newId);
     };
 
+    const setStudyConsent = (consent: Exclude<StudyConsent, null>) => {
+        const storageKey = `module_${moduleId}_study_consent`;
+        localStorage.setItem(storageKey, consent);
+        setStudyConsentState(consent);
+    };
+
+    const clearModuleStoredData = () => {
+        try {
+            const prefixes = [
+                `reflection:${sessionId}:${moduleId}:`,
+                `poll:${sessionId}:${moduleId}:`,
+                `pollSelection:${sessionId}:${moduleId}:`,
+                `numeric-prediction:${sessionId}:${moduleId}:`,
+            ];
+            for (let i = localStorage.length - 1; i >= 0; i--) {
+                const key = localStorage.key(i);
+                if (!key) continue;
+                if (prefixes.some(prefix => key.startsWith(prefix))) {
+                    localStorage.removeItem(key);
+                }
+            }
+        } catch {
+        }
+        startNewSession();
+    };
+
     return (
-        <SessionContext.Provider value={{ sessionId, startNewSession }}>
+        <SessionContext.Provider value={{ sessionId, startNewSession, studyConsent, setStudyConsent, clearModuleStoredData }}>
             {children}
         </SessionContext.Provider>
     );


### PR DESCRIPTION
Implemented a study consent flow that prompts users shortly (10 seconds) after entering a module

**What Changed**
- Shows a “MIT Research Study” consent popup ~10 seconds after opening a module (only if no prior choice for that module).
- Persists consent per module in `localStorage` (`module_<id>_study_consent`) via `SessionContext`.
- Blocks `postInput` submissions and PDF export unless the learner opts in; if consent is unknown and they attempt submit/export, it triggers the popup immediately.
- “Opt out” clears stored module response keys, rotates the module session id, closes the popup, and navigates back to Home.
- Updates the modal UI to be a centered boxed dialog with a dimmed/blurred overlay (improves “real popup” feel) and centers the action buttons.

**Files Changed**
- `src/contexts/SessionContext.tsx` (consent state + persistence + clear/reset helper)
- `src/components/FlexibleModulePage.tsx` (10s timer, dialog UI, centered actions, opt-out -> home)
- `src/components/ContentBlock.tsx` (gate submit/export; request popup when needed)
- `src/components/ui/alert-dialog.tsx` (overlay + boxed modal styling)
