### PR TITLE
End sessions on tab close by moving module session, consent, and response caches to sessionStorage

### DIFF
--- a/src/components/ContentBlock.tsx
+++ b/src/components/ContentBlock.tsx
@@ -37,7 +37,7 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(`poll:${sessionId}:${moduleId}:${block.id}`);
+      const stored = sessionStorage.getItem(`poll:${sessionId}:${moduleId}:${block.id}`);
       if (stored) setLastSubmittedResponse(stored);
     } catch {
     }
@@ -45,7 +45,7 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(`pollSelection:${sessionId}:${moduleId}:${block.id}`);
+      const stored = sessionStorage.getItem(`pollSelection:${sessionId}:${moduleId}:${block.id}`);
       if (!stored) return;
       const parsed = JSON.parse(stored) as unknown;
       if (
@@ -136,13 +136,13 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
       });
       setLastSubmittedResponse(responseDisplay);
       try {
-        localStorage.setItem(`poll:${sessionId}:${moduleId}:${block.id}`, responseDisplay);
+        sessionStorage.setItem(`poll:${sessionId}:${moduleId}:${block.id}`, responseDisplay);
       } catch {
       }
       const submittedSelection = { selectedOptions, otherText };
       setLastSubmittedSelection(submittedSelection);
       try {
-        localStorage.setItem(`pollSelection:${sessionId}:${moduleId}:${block.id}`, JSON.stringify(submittedSelection));
+        sessionStorage.setItem(`pollSelection:${sessionId}:${moduleId}:${block.id}`, JSON.stringify(submittedSelection));
       } catch {
       }
       setSelectedOptions([]);
@@ -443,7 +443,7 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(`reflection:${sessionId}:${moduleId}:${block.id}`);
+      const stored = sessionStorage.getItem(`reflection:${sessionId}:${moduleId}:${block.id}`);
       if (stored) setLastSubmittedText(stored);
     } catch {
     }
@@ -488,7 +488,7 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
       });
       setLastSubmittedText(submittedText);
       try {
-        localStorage.setItem(`reflection:${sessionId}:${moduleId}:${block.id}`, submittedText);
+        sessionStorage.setItem(`reflection:${sessionId}:${moduleId}:${block.id}`, submittedText);
       } catch {
       }
       setReflectionText('');
@@ -561,7 +561,7 @@ function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlo
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(`numeric-prediction:${sessionId}:${moduleId}:${block.id}`);
+      const stored = sessionStorage.getItem(`numeric-prediction:${sessionId}:${moduleId}:${block.id}`);
       if (stored) setLastSubmittedValue(stored);
     } catch {
     }
@@ -610,7 +610,7 @@ function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlo
       });
       setLastSubmittedValue(submittedValue);
       try {
-        localStorage.setItem(`numeric-prediction:${sessionId}:${moduleId}:${block.id}`, submittedValue);
+        sessionStorage.setItem(`numeric-prediction:${sessionId}:${moduleId}:${block.id}`, submittedValue);
       } catch {
       }
       setValueText('');

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -28,9 +28,8 @@ interface SessionProviderProps {
 
 export function SessionProvider({ children, moduleId }: SessionProviderProps) {
     const [sessionId, setSessionId] = useState<string>(() => {
-        // Try to get existing session from localStorage for this module
         const storageKey = `module_${moduleId}_session`;
-        const stored = localStorage.getItem(storageKey);
+        const stored = sessionStorage.getItem(storageKey);
         if (stored) {
             try {
                 // Handle cases where session was stored as a JSON object (e.g., from previous versions)
@@ -41,22 +40,35 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
                 return stored;
             }
         }
-        // Generate new session if none exists
         const newId = generateSessionId();
-        localStorage.setItem(storageKey, newId);
+        try {
+            localStorage.removeItem(storageKey);
+        } catch {
+        }
+        sessionStorage.setItem(storageKey, newId);
         return newId;
     });
 
     const [studyConsent, setStudyConsentState] = useState<StudyConsent>(() => {
         const storageKey = `module_${moduleId}_study_consent`;
-        const stored = localStorage.getItem(storageKey);
-        return stored === 'in' || stored === 'out' ? stored : null;
+        const storedFromSession = sessionStorage.getItem(storageKey);
+        if (storedFromSession === 'in' || storedFromSession === 'out') return storedFromSession;
+        const storedFromLocal = localStorage.getItem(storageKey);
+        if (storedFromLocal === 'in' || storedFromLocal === 'out') {
+            try {
+                localStorage.removeItem(storageKey);
+            } catch {
+            }
+            sessionStorage.setItem(storageKey, storedFromLocal);
+            return storedFromLocal;
+        }
+        return null;
     });
 
     // Update session ID when module changes
     useEffect(() => {
         const storageKey = `module_${moduleId}_session`;
-        const stored = localStorage.getItem(storageKey);
+        const stored = sessionStorage.getItem(storageKey);
         if (stored) {
             try {
                 const parsed = JSON.parse(stored);
@@ -67,27 +79,49 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
             }
         } else {
             const newId = generateSessionId();
-            localStorage.setItem(storageKey, newId);
+            try {
+                localStorage.removeItem(storageKey);
+            } catch {
+            }
+            sessionStorage.setItem(storageKey, newId);
             setSessionId(newId);
         }
     }, [moduleId]);
 
     useEffect(() => {
         const storageKey = `module_${moduleId}_study_consent`;
-        const stored = localStorage.getItem(storageKey);
-        setStudyConsentState(stored === 'in' || stored === 'out' ? stored : null);
+        const storedFromSession = sessionStorage.getItem(storageKey);
+        if (storedFromSession === 'in' || storedFromSession === 'out') {
+            setStudyConsentState(storedFromSession);
+            return;
+        }
+        const storedFromLocal = localStorage.getItem(storageKey);
+        if (storedFromLocal === 'in' || storedFromLocal === 'out') {
+            try {
+                localStorage.removeItem(storageKey);
+            } catch {
+            }
+            sessionStorage.setItem(storageKey, storedFromLocal);
+            setStudyConsentState(storedFromLocal);
+            return;
+        }
+        setStudyConsentState(null);
     }, [moduleId]);
 
     const startNewSession = () => {
         const storageKey = `module_${moduleId}_session`;
         const newId = generateSessionId();
-        localStorage.setItem(storageKey, newId);
+        sessionStorage.setItem(storageKey, newId);
         setSessionId(newId);
     };
 
     const setStudyConsent = (consent: Exclude<StudyConsent, null>) => {
         const storageKey = `module_${moduleId}_study_consent`;
-        localStorage.setItem(storageKey, consent);
+        try {
+            localStorage.removeItem(storageKey);
+        } catch {
+        }
+        sessionStorage.setItem(storageKey, consent);
         setStudyConsentState(consent);
     };
 
@@ -99,11 +133,14 @@ export function SessionProvider({ children, moduleId }: SessionProviderProps) {
                 `pollSelection:${sessionId}:${moduleId}:`,
                 `numeric-prediction:${sessionId}:${moduleId}:`,
             ];
-            for (let i = localStorage.length - 1; i >= 0; i--) {
-                const key = localStorage.key(i);
-                if (!key) continue;
-                if (prefixes.some(prefix => key.startsWith(prefix))) {
-                    localStorage.removeItem(key);
+            const storages: Storage[] = [sessionStorage, localStorage];
+            for (const storage of storages) {
+                for (let i = storage.length - 1; i >= 0; i--) {
+                    const key = storage.key(i);
+                    if (!key) continue;
+                    if (prefixes.some(prefix => key.startsWith(prefix))) {
+                        storage.removeItem(key);
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
Update client-side storage to match the team’s requested behavior: a “session” should end when the browser tab is closed.

**What changed**
- Moved the per-module session ID (`module_${moduleId}_session`) from `localStorage` to `sessionStorage`, so a new session is created for each new tab session.
- Moved study consent (`module_${moduleId}_study_consent`) from `localStorage` to `sessionStorage`, so consent is scoped to the current tab session.
- Moved per-session response caches to `sessionStorage`:
  - `poll:*`, `pollSelection:*`, `reflection:*`, `numeric-prediction:*`
- Left non-session preferences in `localStorage` (theme and language), since those are intended to persist across tab closes.

**Why this fixes the behavior**
- `localStorage` persists after closing the tab, which kept the “session” alive across tab closes.
- `sessionStorage` is cleared when the tab is closed, so session IDs, consent, and cached responses reset automatically on tab close—matching the team’s definition of session lifecycle.

**Notes**
- On first run after this change, previously stored consent in `localStorage` is migrated into `sessionStorage` and removed from `localStorage` to avoid mixed state.

