### PR TITLE
Tag submissions with study consent; update consent dialog to Agree/Disagree and allow opt-out submissions

### DIFF
--- a/src/api/postInput.ts
+++ b/src/api/postInput.ts
@@ -4,6 +4,7 @@ export type PostInputRequest = {
   input: string;
   module_id: string;
   section_id: string;
+  study_consent?: 'in' | 'out' | null;
   timestamp?: string;
   session_id?: string;
 };

--- a/src/components/ContentBlock.tsx
+++ b/src/components/ContentBlock.tsx
@@ -98,14 +98,9 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    if (studyConsent !== 'in') {
-      if (studyConsent === null) {
-        window.dispatchEvent(new Event('study_consent_request'));
-      }
-      setSubmitError(studyConsent === 'out'
-        ? 'You opted out of the study; your responses will not be submitted.'
-        : 'Please choose whether to participate in the study before submitting.'
-      );
+    if (studyConsent === null) {
+      window.dispatchEvent(new Event('study_consent_request'));
+      setSubmitError('Please choose Agree or Disagree before submitting.');
       return;
     }
     const responseDisplay = (() => {
@@ -132,6 +127,7 @@ function PollBlock({ block, moduleId }: { block: Extract<ContentBlockType, { typ
         input,
         module_id: String(moduleId),
         section_id: block.id,
+        study_consent: studyConsent,
         session_id: sessionId,
       });
       setLastSubmittedResponse(responseDisplay);
@@ -277,14 +273,9 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    if (studyConsent !== 'in') {
-      if (studyConsent === null) {
-        window.dispatchEvent(new Event('study_consent_request'));
-      }
-      setSubmitError(studyConsent === 'out'
-        ? 'You opted out of the study; your responses will not be submitted.'
-        : 'Please choose whether to participate in the study before submitting.'
-      );
+    if (studyConsent === null) {
+      window.dispatchEvent(new Event('study_consent_request'));
+      setSubmitError('Please choose Agree or Disagree before submitting.');
       return;
     }
     const input = JSON.stringify({
@@ -304,6 +295,7 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
         input,
         module_id: String(moduleId),
         section_id: block.id,
+        study_consent: studyConsent,
         session_id: sessionId,
       });
       setRating(0);
@@ -319,14 +311,9 @@ function ModuleFeedbackBlock({ block, moduleId }: { block: Extract<ContentBlockT
 
   const handleExport = async () => {
     if (isExporting) return;
-    if (studyConsent !== 'in') {
-      if (studyConsent === null) {
-        window.dispatchEvent(new Event('study_consent_request'));
-      }
-      setExportError(studyConsent === 'out'
-        ? 'You opted out of the study; there are no stored responses to export.'
-        : 'Please choose whether to participate in the study before exporting.'
-      );
+    if (studyConsent === null) {
+      window.dispatchEvent(new Event('study_consent_request'));
+      setExportError('Please choose Agree or Disagree before exporting.');
       return;
     }
     trackEvent('download_pdf', { module_id: moduleId });
@@ -457,14 +444,9 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    if (studyConsent !== 'in') {
-      if (studyConsent === null) {
-        window.dispatchEvent(new Event('study_consent_request'));
-      }
-      setSubmitError(studyConsent === 'out'
-        ? 'You opted out of the study; your responses will not be submitted.'
-        : 'Please choose whether to participate in the study before submitting.'
-      );
+    if (studyConsent === null) {
+      window.dispatchEvent(new Event('study_consent_request'));
+      setSubmitError('Please choose Agree or Disagree before submitting.');
       return;
     }
     const submittedText = reflectionText.trim();
@@ -484,6 +466,7 @@ function ReflectionBlock({ block, moduleId }: { block: Extract<ContentBlockType,
         input,
         module_id: String(moduleId),
         section_id: block.id,
+        study_consent: studyConsent,
         session_id: sessionId,
       });
       setLastSubmittedText(submittedText);
@@ -575,14 +558,9 @@ function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlo
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    if (studyConsent !== 'in') {
-      if (studyConsent === null) {
-        window.dispatchEvent(new Event('study_consent_request'));
-      }
-      setSubmitError(studyConsent === 'out'
-        ? 'You opted out of the study; your responses will not be submitted.'
-        : 'Please choose whether to participate in the study before submitting.'
-      );
+    if (studyConsent === null) {
+      window.dispatchEvent(new Event('study_consent_request'));
+      setSubmitError('Please choose Agree or Disagree before submitting.');
       return;
     }
     const valueNumber = valueText.trim() === '' ? null : Number(valueText);
@@ -606,6 +584,7 @@ function NumericPredictionBlock({ block, moduleId }: { block: Extract<ContentBlo
         input,
         module_id: String(moduleId),
         section_id: block.id,
+        study_consent: studyConsent,
         session_id: sessionId,
       });
       setLastSubmittedValue(submittedValue);

--- a/src/components/FlexibleModulePage.tsx
+++ b/src/components/FlexibleModulePage.tsx
@@ -58,7 +58,7 @@ export function FlexibleModulePage({
   const { search } = useLocation();
   const [currentBlock, setCurrentBlock] = useState(1);
   const [isConsentDialogOpen, setIsConsentDialogOpen] = useState(false);
-  const { studyConsent, setStudyConsent, clearModuleStoredData } = useSession();
+  const { studyConsent, setStudyConsent } = useSession();
   const totalModules = moduleStructures.length;
   const isLastModule = moduleId >= totalModules;
   const consentOpenTimeoutRef = useRef<number | null>(null);
@@ -330,12 +330,10 @@ export function FlexibleModulePage({
             <AlertDialogCancel
               onClick={() => {
                 setStudyConsent('out');
-                clearModuleStoredData();
                 setIsConsentDialogOpen(false);
-                navigate('/');
               }}
             >
-              Opt out
+              Disagree
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
@@ -343,7 +341,7 @@ export function FlexibleModulePage({
                 setIsConsentDialogOpen(false);
               }}
             >
-              Count me in!
+              Agree
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
This PR adjusts the study-consent flow and ensures every learner response is tagged with their consent choice.

- Updates the consent dialog CTA labels to **Disagree / Agree**
- Keeps users on the same module page after clicking **Disagree** (no redirect)
- Allows users who clicked **Disagree** to continue submitting responses (only blocks submission when consent is still unknown/unset)
- Adds `study_consent: 'in' | 'out' | null` to the payload sent to `POST /api/input/post/` for all submission types using `postInput` (poll, reflection, numeric prediction, module feedback)
