### PR TITLE
Updated the study_consent to be required

### DIFF
--- a/src/api/postInput.ts
+++ b/src/api/postInput.ts
@@ -4,7 +4,7 @@ export type PostInputRequest = {
   input: string;
   module_id: string;
   section_id: string;
-  study_consent?: 'in' | 'out' | null;
+  study_consent: 'in' | 'out';
   timestamp?: string;
   session_id?: string;
 };


### PR DESCRIPTION

          
Updated the frontend type to match the backend contract: `study_consent` is now required and non-nullable.

- Change:` postInput.ts`
  - From `study_consent?: 'in' | 'out' | null`
  - To `study_consent: 'in' | 'out'`
